### PR TITLE
Fix crash when getting the selection

### DIFF
--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -43,8 +43,11 @@ function getUpdatedSelectionState(
 
   var anchorPath = DraftOffsetKey.decode(anchorKey);
   var anchorBlockKey = anchorPath.blockKey;
-  var anchorLeaf = editorState
-    .getBlockTree(anchorBlockKey)
+  var anchorBlockTree = editorState.getBlockTree(anchorBlockKey);
+  if (!anchorBlockTree) {
+    return selection;
+  }
+  var anchorLeaf = anchorBlockTree
     .getIn([
       anchorPath.decoratorKey,
       'leaves',
@@ -53,8 +56,11 @@ function getUpdatedSelectionState(
 
   var focusPath = DraftOffsetKey.decode(focusKey);
   var focusBlockKey = focusPath.blockKey;
-  var focusLeaf = editorState
-    .getBlockTree(focusBlockKey)
+  var focusBlockTree = editorState.getBlockTree(focusBlockKey);
+  if (!focusBlockTree) {
+    return selection;
+  }
+  var focusLeaf = focusBlockTree
     .getIn([
       focusPath.decoratorKey,
       'leaves',


### PR DESCRIPTION
This fixes facebook/draft-js#473

When changing editorStates to something completely different, there is a timing window from the time the editor state is set to the new render. In this scenario, draft should verify the DOM selection corresponds to the correct editorState before proceeding