### PR TITLE
Allow editors to handle Option+Space on Chrome

### DIFF
--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -112,23 +112,9 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
       this.props.onDownArrow && this.props.onDownArrow(e);
       return;
     case Keys.SPACE:
-      // Handling for OSX where option + space scrolls.
+      // Prevent Chrome on OSX behavior where option + space scrolls.
       if (isChrome && isOptionKeyCommand(e)) {
         e.preventDefault();
-        // Insert a nbsp into the editor.
-        const contentState = DraftModifier.replaceText(
-          editorState.getCurrentContent(),
-          editorState.getSelection(),
-          '\u00a0'
-        );
-        this.update(
-          EditorState.push(
-            editorState,
-            contentState,
-            'insert-characters'
-          )
-        );
-        return;
       }
   }
 
@@ -136,6 +122,27 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
 
   // If no command is specified, allow keydown event to continue.
   if (!command) {
+    if (
+      keyCode === Keys.SPACE &&
+      isChrome &&
+      isOptionKeyCommand(e)
+    ) {
+      // The default keydown event has already been prevented in order to stop
+      // Chrome from scrolling. Insert a nbsp into the editor as OSX would for
+      // other browsers.
+      const contentState = DraftModifier.replaceText(
+        editorState.getCurrentContent(),
+        editorState.getSelection(),
+        '\u00a0'
+      );
+      this.update(
+        EditorState.push(
+          editorState,
+          contentState,
+          'insert-characters'
+        )
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
Currently, pressing Option + Space in Chrome on maxOS by-passes the key handlers and automatically inserts a nonbreaking space. This is problematic for code that is trying, for example, to ensure that there are no consecutive spaces in the text.
