### PR TITLE
Add suppressSyncingSelection

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -284,6 +284,7 @@ class DraftEditor extends React.Component {
               customStyleFn={this.props.customStyleFn}
               editorKey={this._editorKey}
               editorState={this.props.editorState}
+              suppressSyncingSelection={this.props.suppressSyncingSelection}
             />
           </div>
         </div>

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -119,6 +119,7 @@ export type DraftEditorProps = {
   ) => DraftHandleValue,
 
   allowNativeInsertion?: boolean,
+  suppressSyncingSelection?: boolean,
 
   /**
    * Non-cancelable event triggers.

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -48,6 +48,7 @@ type Props = {
   blockProps?: Object,
   startIndent?: boolean,
   blockStyleFn: Function,
+  suppressSyncingSelection: boolean,
 };
 
 /**
@@ -147,6 +148,7 @@ class DraftEditorBlock extends React.Component {
             customStyleMap={this.props.customStyleMap}
             customStyleFn={this.props.customStyleFn}
             isLast={ii === lastLeafSet && jj === lastLeaf}
+            suppressSyncingSelection={this.props.suppressSyncingSelection}
           />
         );
       }).toArray();

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -29,6 +29,7 @@ type Props = {
   blockRendererFn: Function,
   blockStyleFn: (block: ContentBlock) => string,
   editorState: EditorState,
+  suppressSyncingSelection: boolean,
 };
 
 /**
@@ -97,6 +98,7 @@ class DraftEditorContents extends React.Component {
       customStyleMap,
       customStyleFn,
       editorState,
+      suppressSyncingSelection,
     } = this.props;
 
     const content = editorState.getCurrentContent();
@@ -136,6 +138,7 @@ class DraftEditorContents extends React.Component {
         key,
         offsetKey,
         selection,
+        suppressSyncingSelection,
         tree: editorState.getBlockTree(key),
       };
 

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -36,6 +36,8 @@ type Props = {
   // Whether to force the DOM selection after render.
   forceSelection: boolean,
 
+  suppressSyncingSelection: boolean,
+
   // Whether this leaf is the last in its block. Used for a DOM hack.
   isLast: boolean,
 
@@ -74,10 +76,10 @@ class DraftEditorLeaf extends React.Component {
    * text nodes, this would be harder.
    */
   _setSelection(): void {
-    const {selection} = this.props;
+    const { selection, suppressSyncingSelection } = this.props;
 
     // If selection state is irrelevant to the parent block, no-op.
-    if (selection == null || !selection.getHasFocus()) {
+    if (selection == null || !selection.getHasFocus() || suppressSyncingSelection) {
       return;
     }
 


### PR DESCRIPTION
Allow callers to prevent forcing the DOM selection to the current
location. This way the state of the editor can be maintained without it
stealing the selection when it shouldn't. Instead, this gets deferred
until suppressSyncingSelection gets turned off.