### PR TITLE
normal is not bold

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -54,7 +54,7 @@ var REGEX_ZWS = new RegExp('&#8203;?', 'g');
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
 const boldValues = ['bold', 'bolder', '500', '600', '700', '800', '900'];
-const notBoldValues = ['light', 'lighter', '100', '200', '300', '400'];
+const notBoldValues = ['normal', 'light', 'lighter', '100', '200', '300', '400'];
 
 // Block tag flow is different because LIs do not have
 // a deterministic style ;_;


### PR DESCRIPTION
For whatever reason `font-weight: normal` is not counted as not being bold. This causes https://github.com/textioHQ/helens/issues/401.