### PR TITLE
Outer-most block type should take preference

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -156,7 +156,6 @@ function getListBlockType(
 function getBlockMapSupportedTags(
   blockRenderMap: DraftBlockRenderMap
 ): Array<string> {
-  const unstyledElement = blockRenderMap.get('unstyled').element;
   let tags = new Set([]);
 
   blockRenderMap.forEach((draftBlock: DraftBlockRenderConfig) => {
@@ -170,7 +169,6 @@ function getBlockMapSupportedTags(
   });
 
   return tags
-    .filter((tag) => tag && tag !== unstyledElement)
     .toArray()
     .sort();
 }
@@ -430,7 +428,13 @@ function genFragment(
   }
 
   // Block Tags
-  if (!inBlock && blockTags.indexOf(nodeName) !== -1) {
+  if (
+    (
+      !inBlock ||
+      getBlockTypeForTag(inBlock, lastList, blockRenderMap) === 'unstyled'
+    ) &&
+    blockTags.indexOf(nodeName) !== -1
+  ) {
     chunk = getBlockDividerChunk(
       getBlockTypeForTag(nodeName, lastList, blockRenderMap),
       depth

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -127,18 +127,22 @@ describe('DraftPasteProcessor', function() {
     ]);
   });
 
-  /**
-   * todo: azelenskiy
-   * Changes to the mocked DOM appear to have broken this.
-   *
-   * it('must suppress blocks nested inside other blocks', function() {
-   *   var html = '<p><h2>Some text here</h2> more text here </p>';
-   *   var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-   *   assertBlockTypes(output, [
-   *   'unstyled',
-   *   ]);
-   * });
-   */
+  it('must suppress blocks nested inside other blocks', function() {
+    var html = '<h2><p>Some text here</p> more text here </h2>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertBlockTypes(output, [
+      'header-two',
+    ]);
+  });
+
+  it('must not suppress blocks nested inside unstyled blocks', function() {
+    var html = '<div><h2>Some text here</h2> more text here </div>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertBlockTypes(output, [
+      'header-two',
+      'unstyled',
+    ]);
+  });
 
   it('must detect two touching blocks', function() {
     var html = '<h1>hi</h1>    <h2>hi</h2>';
@@ -194,12 +198,22 @@ describe('DraftPasteProcessor', function() {
     ]);
   });
 
-  it('must NOT treat divs as Ps when we pave Ps', function() {
+  it('must NOT treat divs as Ps when they contain Ps', function() {
     var html = '<div><p>hi</p><p>hello</p></div>';
     var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
     assertBlockTypes(output, [
       'paragraph',
       'paragraph',
+    ]);
+  });
+
+  it('must treat divs that do not contain Ps as Ps when we have Ps elsewhere', function() {
+    var html = '<p>hi</p><div>hello</div><div>hola</div>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertBlockTypes(output, [
+      'paragraph',
+      'unstyled',
+      'unstyled',
     ]);
   });
 


### PR DESCRIPTION
Currently unstyled blocks (but not their aliases) are ignored whenever any other blocks also need to be converted. This ensures that cases like `<div><h2>Hello world!</h2></div>` are properly marked as `header-two` but it creates a parsing difference between `<div>Hello</div><div>world</div>` and `<h2>Good morning!</h2><div>Hello</div><div>world</div>` in which the former has `Hello` and `world` in two different blocks but the latter has them in one.

The goal for parsing is that if the block that's being parsed is in something other than an unstyled block then it is part of its parent otherwise it's a new block. This ensures even unstyled blocks are always treated as blocks and moves the check for whether a block is unstyled deeper into the parsing logic.
