### PR TITLE
500 shouldn't be bold

### DIFF
--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -138,10 +138,10 @@ function addFocusToSelection(
     // Additionally, clone the selection range. IE11 throws an
     // InvalidStateError when attempting to access selection properties
     // after the range is detached.
-    if(selection.rangeCount > 0) {
-        var range = selection.getRangeAt(0);
-        range.setEnd(node, offset);
-        selection.addRange(range.cloneRange());
+    if (selection.rangeCount > 0) {
+      var range = selection.getRangeAt(0);
+      range.setEnd(node, offset);
+      selection.addRange(range.cloneRange());
     }
   }
 }

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -53,6 +53,8 @@ var REGEX_CARRIAGE = new RegExp('&#13;?', 'g');
 var REGEX_ZWS = new RegExp('&#8203;?', 'g');
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
+// According to the MDN page, for fonts which provide only normal and bold
+// 100-500 are normal and 600-900 are bold.
 const boldValues = ['bold', 'bolder', '600', '700', '800', '900'];
 const notBoldValues = ['normal', 'light', 'lighter', '100', '200', '300', '400', '500'];
 

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -53,8 +53,8 @@ var REGEX_CARRIAGE = new RegExp('&#13;?', 'g');
 var REGEX_ZWS = new RegExp('&#8203;?', 'g');
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
-const boldValues = ['bold', 'bolder', '500', '600', '700', '800', '900'];
-const notBoldValues = ['normal', 'light', 'lighter', '100', '200', '300', '400'];
+const boldValues = ['bold', 'bolder', '600', '700', '800', '900'];
+const notBoldValues = ['normal', 'light', 'lighter', '100', '200', '300', '400', '500'];
 
 // Block tag flow is different because LIs do not have
 // a deterministic style ;_;


### PR DESCRIPTION
MDN list's a heuristic that  interprets it as normal for some fonts.

This also includes a lint fix.

Fixes https://github.com/textioHQ/helens/issues/508