### PR TITLE
Catch all errors setting the selection

### DIFF
--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -106,7 +106,15 @@ class DraftEditorLeaf extends React.Component {
       targetNode = child.firstChild;
     }
 
-    setDraftEditorSelection(selection, targetNode, blockKey, start, end);
+    try {
+      setDraftEditorSelection(selection, targetNode, blockKey, start, end);
+    } catch (e) {
+      // Sometimes, setting the selection appears to fail on IE11 with different errors,
+      // specifically 800a025e as one example.
+      // In general, just catch this error and treat it as non-fatal.
+      // Yes, it is unfortunate that the DOM selection will not be correct, but this can be fixed
+      // by the user and then the editor can successfully recover.
+    }
   }
 
   shouldComponentUpdate(nextProps: Props): boolean {


### PR DESCRIPTION
This fixes textioHQ/helens#574 and possibly other bugs.

We have run into issues throughout our journey into contenteditable where setting or manipulating the DOM selection has led to exceptions. This has primarily been in IE11, but we've also seen it in firefox, safari, etc. in scenarios that make no sense.

The fix here is a blanket try/catch to eat any selection related error. The user can recover by manually setting the selection.