### PR TITLE
Fix IE11 selection bug

### DIFF
--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -98,10 +98,10 @@ class DraftEditorLeaf extends React.Component {
       targetNode = child;
     } else if (child.tagName === 'BR') {
       targetNode = node;
-    } else if (child.firstChild && child.firstChild.nextSibling) {
+    } else if (child.firstChild.getAttribute('data-mozilla-fix') === 'true') {
       // We've added an extra span (see DraftEditorTextNode.react.js) to prevent Firefox spellcheck from destroying
-      // our content. Skip past the span and the react text comment to get to the real text node.
-      targetNode = child.firstChild.nextSibling.nextSibling;
+      // our content. Skip past the span to get to the real text node.
+      targetNode = child.firstChild.nextSibling.firstChild;
     } else {
       targetNode = child.firstChild;
     }

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -86,7 +86,7 @@ class DraftEditorTextNode extends React.Component {
       return this._forceFlag ? NEWLINE_A : NEWLINE_B;
     }
 
-    const displayNone = {
+    const mozillaFix = {
       display: 'none',
     };
 
@@ -94,9 +94,11 @@ class DraftEditorTextNode extends React.Component {
     // These spans are necessary to recover what the spellcheck replacement did during the onInput handler. If we add
     // an extra span with a comment in it, Gecko's code doesn't destroy our content.
     return (
-      <span key={this._forceFlag ? 'A' : 'B'} data-text="true">
-        <span style={displayNone} dangerouslySetInnerHTML={{__html: '<!-- gecko patch -->' }}></span>
-        {this.props.children}
+      <span key={this._forceFlag ? 'A' : 'B'} data-outer-text="true">
+        <span data-mozilla-fix="true" style={mozillaFix} dangerouslySetInnerHTML={{__html: '<!-- mozilla fix -->' }}></span>
+        <span data-text="true">
+          {this.props.children}
+        </span>
       </span>
     );
   }


### PR DESCRIPTION
Fixes https://github.com/textioHQ/helens/issues/567
Needs to be merged with https://github.com/textioHQ/frontend/pull/2189

The frontend change is necessary because we are creating a "*+*" selection match with the two spans and the margin-top is picked up by the gutter height code, which results in incorrect block heights being calculated