### PR TITLE
Support pasting html from IE, Edge, and Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.26",
+  "version": "0.10.26-html.0",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.26-html.3",
+  "version": "0.10.26-html.4",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.26-html.1",
+  "version": "0.10.26-html.2",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.26-html.4",
+  "version": "0.10.26-html.5",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.26-html.0",
+  "version": "0.10.26-html.1",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.26-html.2",
+  "version": "0.10.26-html.3",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -274,7 +274,6 @@ class DraftEditor extends React.Component {
             onKeyPress={this._onKeyPress}
             onKeyUp={this._onKeyUp}
             onMouseUp={this._onMouseUp}
-            onPaste={this._onPaste}
             onSelect={this._onSelect}
             ref="editor"
             role={readOnly ? null : (this.props.role || 'textbox')}
@@ -307,6 +306,8 @@ class DraftEditor extends React.Component {
 
   componentDidMount(): void {
     this.setMode('edit');
+    const editorNode = ReactDOM.findDOMNode(this.refs.editor);
+    editorNode.addEventListener('paste', this._onPaste);
 
     /**
      * IE has a hardcoded "feature" that attempts to convert link text into

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -232,6 +232,7 @@ class DraftEditor extends React.Component {
       overflow: 'hidden',
       position: 'absolute',
       opacity: '0.01',
+      display: 'none',
     };
 
     return (

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -232,7 +232,6 @@ class DraftEditor extends React.Component {
       overflow: 'hidden',
       position: 'absolute',
       opacity: '0.01',
-      display: 'none',
     };
 
     return (

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -321,6 +321,11 @@ class DraftEditor extends React.Component {
     }
   }
 
+  componentWillUnmount(): void {
+    const editorNode = ReactDOM.findDOMNode(this.refs.editor);
+    editorNode.removeEventListener('paste', this._onPaste);
+  }
+
   /**
    * Prevent selection events from affecting the current editor state. This
    * is mostly intended to defend against IE, which fires off `selectionchange`

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -306,6 +306,11 @@ class DraftEditor extends React.Component {
 
   componentDidMount(): void {
     this.setMode('edit');
+
+    // Unfortunately, due to https://github.com/facebook/react/issues/8909
+    // it is not possible to set up an onPaste handler through react.
+    // Manually use addEventListener and removeEventListener below.
+    // See the comments in editOnPaste for why this is needed.
     const editorNode = ReactDOM.findDOMNode(this.refs.editor);
     editorNode.addEventListener('paste', this._onPaste);
 

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -54,6 +54,7 @@ const handlerMap = {
   'drag': DraftEditorDragHandler,
   'cut': null,
   'render': null,
+  'paste': null,
 };
 
 type State = {
@@ -225,6 +226,14 @@ class DraftEditor extends React.Component {
       wordWrap: 'break-word',
     };
 
+    const pasteTrapStyle = {
+      maxWidth: '1px',
+      maxHeight: '1px',
+      overflow: 'hidden',
+      position: 'absolute',
+      opacity: '0.01',
+    };
+
     return (
       <div className={rootClass}>
         {this._renderPlaceholder()}
@@ -285,6 +294,12 @@ class DraftEditor extends React.Component {
               editorState={this.props.editorState}
             />
           </div>
+        </div>
+        <div
+          contentEditable={true}
+          style={pasteTrapStyle}
+          ref={ref => this._pasteTrap = ref }
+          suppressContentEditableWarning>
         </div>
       </div>
     );

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -105,7 +105,7 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
     // Do NOT call e.preventDefault(). Instead, we want the browser to paste, just not in the editor element.
     // Instead, move focus to a dummy contentEditable div (the pasteTrap),
     // let the paste event through, and then copy the html out of the paste trap.
-    // It is important to call setMode('paste') to disable draft's event handlers (so it is blisfully unaware)
+    // It is important to call setMode('paste') to disable the editor's event handlers (so it is blisfully unaware)
     // and then to properly undo the sleight-of-hand created.
     editor.setMode('paste');
     const pasteTrap = editor._pasteTrap;

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -109,13 +109,11 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
     // and then to properly undo the sleight-of-hand created.
     editor.setMode('paste');
     const pasteTrap = editor._pasteTrap;
-    pasteTrap.setAttribute('display', 'block');
     pasteTrap.focus();
     setImmediate(() => {
       html = pasteTrap.innerHTML;
       editor.focus();
       pasteTrap.innerHTML = '';
-      pasteTrap.setAttribute('display', 'none');
       editor.exitCurrentMode();
       handleTextualPaste(editor, text, html);
     });

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -40,7 +40,7 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
   // the contentEditable div. So, e in this case comes from a direct editor.addEventListener
   // Therefore, we need to replicate anything that the SyntheticClipboardEvent does that is used
   // Currently, that is only getting the clipboard, which involves falling back to window for IE & Edge.
-  const clipboard = e.clipboardData ? e.clipboardData : window.clipboardData;
+  const clipboard = 'clipboardData' in event ? e.clipboardData : window.clipboardData;
   var data = new DataTransfer(clipboard);
 
   // Get files, unless this is likely to be a string the user wants inline.
@@ -102,7 +102,7 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
   if (text && !html) {
     // The pasted content has text, but not HTML. For certain browsers (old versions of Safari, IE, and Edge)
     // the html isn't provided as part of the clipboardData. To work around this, follow the following algorithm:
-    // Do NOT call e.preventDefault(). Instead, we want the browser to paste, just not in the draft element.
+    // Do NOT call e.preventDefault(). Instead, we want the browser to paste, just not in the editor element.
     // Instead, move focus to a dummy contentEditable div (the pasteTrap),
     // let the paste event through, and then copy the html out of the paste trap.
     // It is important to call setMode('paste') to disable draft's event handlers (so it is blisfully unaware)

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -104,15 +104,15 @@ function editOnPaste(editor: DraftEditor, e): void {
       editor.focus();
       pasteTrap.innerHTML = '';
       editor.exitCurrentMode();
-      handleTextualPaste(editor, text, html, true);
+      handleTextualPaste(editor, text, html);
     });
   } else {
     e.preventDefault();
-    handleTextualPaste(editor, text, html, data.isRichText());
+    handleTextualPaste(editor, text, html);
   }
 }
 
-function handleTextualPaste(editor, text, html, isRichText) {
+function handleTextualPaste(editor, text, html) {
   let textBlocks: Array<string> = [];
 
   if (
@@ -135,6 +135,7 @@ function handleTextualPaste(editor, text, html, isRichText) {
     // editor in Firefox and IE will not include empty lines. The resulting
     // paste will preserve the newlines correctly.
     const internalClipboard = editor.getClipboard();
+    const isRichText = text && html;
     if (isRichText && internalClipboard) {
       if (
         // If the editorKey is present in the pasted HTML, it should be safe to

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -97,7 +97,7 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
   }
 
   const text = data.getText();
-  let html = getHTML();
+  let html = getHTML(data);
 
   if (text && !html) {
     // The pasted content has text, but not HTML. For certain browsers (old versions of Safari, IE, and Edge)

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -97,7 +97,7 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
   }
 
   const text = data.getText();
-  let html = data.getHTML();
+  let html = getHTML();
 
   if (text && !html) {
     // The pasted content has text, but not HTML. For certain browsers (old versions of Safari, IE, and Edge)
@@ -209,6 +209,14 @@ function handleTextualPaste(editor, text, html) {
     var textMap = BlockMapBuilder.createFromArray(textFragment);
     editor.update(insertFragment(editor._latestEditorState, textMap));
   }
+}
+
+function getHTML(data: DataTransfer) {
+  // Work around DataTransfer issue in IE11 https://github.com/facebook/draft-js/issues/656
+  if (data.data.getData && !data.types.length) {
+    return undefined;
+  }
+  return data.getHTML();
 }
 
 function insertFragment(

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -109,11 +109,13 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
     // and then to properly undo the sleight-of-hand created.
     editor.setMode('paste');
     const pasteTrap = editor._pasteTrap;
+    pasteTrap.setAttribute('display', 'block');
     pasteTrap.focus();
     setImmediate(() => {
       html = pasteTrap.innerHTML;
       editor.focus();
       pasteTrap.innerHTML = '';
+      pasteTrap.setAttribute('display', 'none');
       editor.exitCurrentMode();
       handleTextualPaste(editor, text, html);
     });


### PR DESCRIPTION
For browsers that don't support grabbing the html out of the clipboardData, instead allow the paste event to go to a dummy pasteTrap and then use that in the remainder of the code