### PR TITLE
Reset selection on input for Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -78,14 +78,14 @@ function editOnInput(editor: DraftEditor): void {
     return;
   }
 
-  // Most browsers fire a selection event before making spellcheck
-  // and autocorrect changes, but Edge doesn't. We need to grab the
+  // Most browsers fire a selection event when the user right-clicks
+  // to bring up the context menu, but Edge doesn't. We need to grab the
   // current selection to make sure we're modifying the right block.
   if (isEdge) {
     editOnSelect(editor);
+    editorState = editor._latestEditorState;
   }
 
-  editorState = editor._latestEditorState;
   var selection = editorState.getSelection();
 
   // We'll replace the entire leaf with the text content of the target.

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -45,14 +45,6 @@ function editOnInput(editor: DraftEditor): void {
     editor.update(editor._pendingStateFromBeforeInput);
     editor._pendingStateFromBeforeInput = undefined;
   }
-
-  // Most browsers fire a selection event before making spellcheck
-  // and autocorrect changes, but Edge doesn't. We need to grab the
-  // current selection to make sure we're modifying the right block.
-  if (isEdge) {
-    editOnSelect(editor);
-  }
-
   var domSelection = global.getSelection();
 
   var {anchorNode, isCollapsed} = domSelection;
@@ -84,6 +76,13 @@ function editOnInput(editor: DraftEditor): void {
   // No change -- the DOM is up to date. Nothing to do here.
   if (domText === modelText) {
     return;
+  }
+
+  // Most browsers fire a selection event before making spellcheck
+  // and autocorrect changes, but Edge doesn't. We need to grab the
+  // current selection to make sure we're modifying the right block.
+  if (isEdge) {
+    editOnSelect(editor);
   }
 
   var selection = editorState.getSelection();

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -85,6 +85,7 @@ function editOnInput(editor: DraftEditor): void {
     editOnSelect(editor);
   }
 
+  editorState = editor._latestEditorState;
   var selection = editorState.getSelection();
 
   // We'll replace the entire leaf with the text content of the target.


### PR DESCRIPTION
Edge, unlike other browsers, doesn't fire a selection even before making an autocorrect change so we need to manually reconcile window.getSelection() with our internal state at the time of the input event.

Fixes https://github.com/textioHQ/editor/issues/619