### PR TITLE
Create copy trap div

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -226,7 +226,7 @@ class DraftEditor extends React.Component {
       wordWrap: 'break-word',
     };
 
-    const pasteTrapStyle = {
+    const trapDivStyle = {
       maxWidth: '1px',
       maxHeight: '1px',
       overflow: 'hidden',
@@ -297,8 +297,14 @@ class DraftEditor extends React.Component {
         </div>
         <div
           contentEditable={true}
-          style={pasteTrapStyle}
+          style={trapDivStyle}
           ref={ref => this._pasteTrap = ref }
+          suppressContentEditableWarning>
+        </div>
+        <div
+          contentEditable={true}
+          style={trapDivStyle}
+          ref={ref => this._copyTrap = ref }
           suppressContentEditableWarning>
         </div>
       </div>

--- a/src/component/handlers/edit/editOnCopy.js
+++ b/src/component/handlers/edit/editOnCopy.js
@@ -35,11 +35,10 @@ function editOnCopy(editor: DraftEditor, e: SyntheticClipboardEvent): void {
 
   const fragment = getFragmentFromSelection(editor._latestEditorState);
   editor.setClipboard(fragment);
+
   if (editor.props.convertBlockMapToClipboard) {
     const clipboardDataToSet = editor.props.convertBlockMapToClipboard(fragment);
-    setClipboardData(e, clipboardDataToSet);
-
-    e.preventDefault();
+    setClipboardData(e, editor, clipboardDataToSet);
   }
 }
 

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -62,9 +62,7 @@ function editOnCut(editor: DraftEditor, e: SyntheticClipboardEvent): void {
 
   if (editor.props.convertBlockMapToClipboard) {
     const clipboardDataToSet = editor.props.convertBlockMapToClipboard(fragment);
-    setClipboardData(e, clipboardDataToSet);
-
-    e.preventDefault();
+    setClipboardData(e, editor, clipboardDataToSet);
   }
 }
 

--- a/src/component/handlers/edit/setClipboardData.js
+++ b/src/component/handlers/edit/setClipboardData.js
@@ -12,7 +12,38 @@
 
 'use strict';
 
-function setClipboardData(e: SyntheticClipboardEvent, { text, html }): void {
+import type DraftEditor from 'DraftEditor.react';
+
+var UserAgent = require('UserAgent');
+var setImmediate = require('setImmediate');
+
+var isIE = UserAgent.isBrowser('IE');
+
+function setClipboardData(e: SyntheticClipboardEvent, editor: DraftEditor, { text, html }): void {
+  if (isIE) {
+
+    // We can't always set the clipboard data in IE because of various Group Policies that might be applied.
+    // We need to populate a "copy trap" div with the new HTML and switch focus so the native copy can go
+    // through into that div
+    editor._copyTrap.innerHTML = html;
+
+    var selection = window.getSelection();
+    var copyTrapRange = document.createRange();
+    copyTrapRange.selectNodeContents(editor._copyTrap);
+    selection.removeAllRanges();
+    selection.addRange(copyTrapRange);
+
+    editor._copyTrap.focus();
+
+    setImmediate(() => {
+      editor.focus();
+      editor._copyTrap.innerHtml = '';
+    });
+
+    // Let the native event go through
+    return;
+  }
+
   // IE doesn't pass a clipboardData object in the event and instead has a non-standard one attached to window
   let clipboard = window.clipboardData;
   if (!clipboard) {
@@ -27,6 +58,8 @@ function setClipboardData(e: SyntheticClipboardEvent, { text, html }): void {
   catch (err) {
     clipboard.setData(`Text`, text);
   }
+
+  e.preventDefault();
 }
 
 module.exports = setClipboardData;


### PR DESCRIPTION
to handle when IE doesn't allow mucking with native copy events. we'll just
let the native copy go through into a copy trap div that gets populated
with the HTML we want in the clipboard.