### PR TITLE
Validate the anchor and focusLeaf

### DIFF
--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -53,6 +53,9 @@ function getUpdatedSelectionState(
       'leaves',
       anchorPath.leafKey,
     ]);
+  if (!anchorLeaf) {
+    return selection;
+  }
 
   var focusPath = DraftOffsetKey.decode(focusKey);
   var focusBlockKey = focusPath.blockKey;
@@ -66,12 +69,15 @@ function getUpdatedSelectionState(
       'leaves',
       focusPath.leafKey,
     ]);
+  if (!focusLeaf) {
+    return selection;
+  }
 
   var anchorLeafStart: number = anchorLeaf.get('start');
   var focusLeafStart: number = focusLeaf.get('start');
 
-  var anchorBlockOffset = anchorLeaf ? anchorLeafStart + anchorOffset : null;
-  var focusBlockOffset = focusLeaf ? focusLeafStart + focusOffset : null;
+  var anchorBlockOffset = anchorLeafStart + anchorOffset;
+  var focusBlockOffset = focusLeafStart + focusOffset;
 
   var areEqual = (
     selection.getAnchorKey() === anchorBlockKey &&


### PR DESCRIPTION
This fixes textioHQ/frontend#2211

This is a continuation of other issues seen in this file, most likely
due to timing issues w.r.t the editorState and the DOM.

Basically, what happens is that this function is trying to take
selection information as from the DOM, and convert that into a logical
selectionState that matches whatever is in editorState. A previous fix
to this file validated the anchorBlockTree and focusBlockTree. This fix
continues the same pattern by validating that the editorState matches
the DOM.

There is this half-attempt already in the codebase to validate the
anchorLeaf & focusLeaf, but it is incomplete (and thus we are hitting
the crash trying to reference it below).