### PR TITLE
This fixes textioHQ/frontend#2303

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -190,8 +190,6 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
       editor._waitingOnInput = false;
       editor._renderNativeContent = false;
     }
-
-
   }
 }
 

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -173,11 +173,25 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     editor._waitingOnInput = true;
     editor.update(newEditorState, true);
 
-    if (isIE) {
-      setImmediate(() => {
-        editOnInput(editor);
-      });
+    var finalEditorState = editor._latestEditorState;
+    var finalContent = finalEditorState.getCurrentContent();
+    var finalNativelyRenderedContent = finalEditorState.getNativelyRenderedContent();
+
+    if (finalNativelyRenderedContent && finalNativelyRenderedContent === finalContent) {
+      if (isIE) {
+        setImmediate(() => {
+          editOnInput(editor);
+        });
+      }
+    } else {
+      // Outside callers (via the editor.onChange prop) have changed the editorState
+      // No longer allow native insertion.
+      e.preventDefault();
+      editor._waitingOnInput = false;
+      editor._renderNativeContent = false;
     }
+
+
   }
 }
 

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -334,6 +334,33 @@ class EditorState {
   }
 
   /**
+   * Replace the contentState with the new one, without altering the undo stack
+   * This should only be used in limited circumstances where the selection is unaltered
+   * and the goal is to provide a silent transformation which is not user-visible
+   */
+  static replace(
+    editorState: EditorState,
+    contentState: ContentState,
+    forceSelection: boolean = editorState.mustForceSelection(),
+): EditorState {
+    var oldContent = editorState.getCurrentContent();
+    if (oldContent.getSelectionAfter() !== contentState.getSelectionAfter()) {
+      throw new Error('Cannot replace the content when the selection differs. Use push instead');
+    }
+
+    var directionMap = EditorBidiService.getDirectionMap(
+      contentState,
+      editorState.getDirectionMap()
+    );
+
+    return EditorState.set(editorState, {
+      currentContent: contentState,
+      directionMap,
+      forceSelection,
+    });
+  }
+
+  /**
    * Push the current ContentState onto the undo stack if it should be
    * considered a boundary state, and set the provided ContentState as the
    * new current content.

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -336,12 +336,11 @@ class EditorState {
   /**
    * Replace the contentState with the new one, without altering the undo stack
    * This should only be used in limited circumstances where the selection is unaltered
-   * and the goal is to provide a silent transformation which is not user-visible
+   * and the goal is to provide a silent transformation
    */
   static replace(
     editorState: EditorState,
-    contentState: ContentState,
-    forceSelection: boolean = editorState.mustForceSelection(),
+    contentState: ContentState
 ): EditorState {
     var oldContent = editorState.getCurrentContent();
     if (oldContent.getSelectionAfter() !== contentState.getSelectionAfter()) {
@@ -356,7 +355,6 @@ class EditorState {
     return EditorState.set(editorState, {
       currentContent: contentState,
       directionMap,
-      forceSelection,
     });
   }
 


### PR DESCRIPTION
There are two parts of this fix:
First, this exposes a public EditorState.replace API to be consumed by
outside callers. We have a need to change the contentState without
triggering the undostack or related behavior. This function exposes the
proper way in which to do so.

Secondly, when going down the native codepath route, there is a chance
that outside callers can change the contentState during the onChange()
handler. If that happens, we need to cancel the native behavior and
render the code normally.