### PR TITLE
Remove the mozilla spellcheck fix as we're implementing spellcheck ourselves

### DIFF
--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -98,12 +98,6 @@ class DraftEditorLeaf extends React.Component {
       targetNode = child;
     } else if (child.tagName === 'BR') {
       targetNode = node;
-    } else if (child.firstChild.nodeType === Node.ELEMENT_NODE &&
-        child.firstChild.getAttribute('data-mozilla-fix') === 'true'
-    ) {
-      // We've added an extra span (see DraftEditorTextNode.react.js) to prevent Firefox spellcheck from destroying
-      // our content. Skip past the span to get to the real text node.
-      targetNode = child.firstChild.nextSibling.firstChild;
     } else {
       targetNode = child.firstChild;
     }

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -85,20 +85,9 @@ class DraftEditorTextNode extends React.Component {
     if (this.props.children === '') {
       return this._forceFlag ? NEWLINE_A : NEWLINE_B;
     }
-
-    const mozillaFix = {
-      display: 'none',
-    };
-
-    // In Firefox, spellcheck handling under certain circumstances causes our "data-offset-key" spans to be destroyed.
-    // These spans are necessary to recover what the spellcheck replacement did during the onInput handler. If we add
-    // an extra span with a comment in it, Gecko's code doesn't destroy our content.
     return (
-      <span key={this._forceFlag ? 'A' : 'B'} data-outer-text="true">
-        <span data-mozilla-fix="true" style={mozillaFix} dangerouslySetInnerHTML={{__html: '<!-- mozilla fix -->' }}></span>
-        <span data-text="true">
-          {this.props.children}
-        </span>
+      <span key={this._forceFlag ? 'A' : 'B'} data-text="true">
+        {this.props.children}
       </span>
     );
   }


### PR DESCRIPTION
See https://github.com/textioHQ/draft-js/commit/987c5667c1e69b967c0fb50f08203a463ee999e5
See https://github.com/textioHQ/draft-js/commit/c937ca704cbcdd8f1abab28074b3913bed04a2d2