### PR TITLE
Don't generate new leaves for empty inline styles

### DIFF
--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -26,6 +26,7 @@ var {
   List,
   Repeat,
   Record,
+  OrderedSet,
 } = Immutable;
 
 var returnTrue = emptyFunction.thatReturnsTrue;
@@ -137,7 +138,7 @@ function generateLeaves(
   var inlineStyles = characters.map(c => c.getStyle()).toList();
   findRangesImmutable(
     inlineStyles,
-    areEqual,
+    areInlineStylesEqual,
     returnTrue,
     (start, end) => {
       leaves.push(
@@ -153,6 +154,10 @@ function generateLeaves(
 
 function areEqual(a: any, b: any): boolean {
   return a === b;
+}
+
+function areInlineStylesEqual(a: OrderedSet, b: OrderedSet) {
+    return a === b || a.size === 0 && b.size === 0;
 }
 
 module.exports = BlockTree;


### PR DESCRIPTION
New leaves are generated when typing in contexts where CharacterMetadata.create() is called with an inline style filled in. There are several places where draft just uses new OrderedMap() instead of trying to use the same inline styles. Rather than try to export an empty OrderedMap object we can just check to make sure size is 0