### PR TITLE
Don't create new leaves for empty inline styles

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -454,7 +454,10 @@ class DraftEditor extends React.Component {
    */
   _restoreEditorDOM(scrollPosition?: DraftScrollPosition): void {
     this.setState({containerKey: this.state.containerKey + 1}, () => {
-      this._focus(scrollPosition);
+
+      // This setTimeout ensures the editor doesn't jitter in IE as
+      // the focus event can happen before the editor is fully rendered
+      this.setTimeout(this._focus(scrollPosition), 0);
     });
   }
 


### PR DESCRIPTION
This should be the same code change as https://github.com/textioHQ/draft-js/pull/43

I thought it was causing problems but it was a different section of code in editor