### PR TITLE
Changed reference editor state in focus method.

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -391,7 +391,7 @@ class DraftEditor extends React.Component {
    * scroll state and put it back in place after focus has been forced.
    */
   _focus(scrollPosition?: DraftScrollPosition): void {
-    const {editorState} = this.props;
+    const editorState = this._latestEditorState;
     const alreadyHasFocus = editorState.getSelection().getHasFocus();
     const editorNode = ReactDOM.findDOMNode(this._editor);
 


### PR DESCRIPTION
**Summary**

Switched so that the focus method makes changes to state based on `_latestEditorState` instead of its props to eliminate weird race conditions. When `DraftEditor.update` is called, it sets `DraftEditor._latestEditorState`, but if focus is called in the `props.onChange` handler before the component has rerendered, the props will be out of date, and the new state will be overwritten with an old one. Switching to using `_latestEditorState` ensures that calling focus isn't sensitive to the timing of rerenders and updates. 
