### PR TITLE
Revert "Revert "Changed reference editor state in focus method.""

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -391,7 +391,7 @@ class DraftEditor extends React.Component {
    * scroll state and put it back in place after focus has been forced.
    */
   _focus(scrollPosition?: DraftScrollPosition): void {
-    const {editorState} = this.props;
+    const editorState = this._latestEditorState;
     const alreadyHasFocus = editorState.getSelection().getHasFocus();
     const editorNode = ReactDOM.findDOMNode(this._editor);
 

--- a/src/model/encoding/convertFromRawToContentBlock.js
+++ b/src/model/encoding/convertFromRawToContentBlock.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule convertFromRawToDraftState
+ * @providesModule convertFromRawToContentBlock
  * @flow
  */
 


### PR DESCRIPTION
Reverts textioHQ/draft-js#49

Now that pitches are over, can include [this change](https://github.com/textioHQ/draft-js/pull/48). 