### PR TITLE
Entity array can have fewer elements than its length

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -112,14 +112,10 @@ function getEmptyChunk(): Chunk {
 }
 
 function getWhitespaceChunk(inEntity: ?string): Chunk {
-  var entities = new Array(1);
-  if (inEntity) {
-    entities[0] = inEntity;
-  }
   return {
     text: SPACE,
     inlines: [OrderedSet()],
-    entities,
+    entities: [inEntity],
     blocks: [],
   };
 }
@@ -128,7 +124,7 @@ function getSoftNewlineChunk(): Chunk {
   return {
     text: '\n',
     inlines: [OrderedSet()],
-    entities: new Array(1),
+    entities: [undefined],
     blocks: [],
   };
 }
@@ -137,7 +133,7 @@ function getBlockDividerChunk(block: DraftBlockType, depth: number): Chunk {
   return {
     text: '\r',
     inlines: [OrderedSet()],
-    entities: new Array(1),
+    entities: [undefined],
     blocks: [{
       type: block,
       depth: Math.max(0, Math.min(MAX_DEPTH, depth)),


### PR DESCRIPTION
`joinChunks` will sometimes concat to arrays which have had their length set without creating all elements. Not all browsers handle these arrays properly.

Fixes https://github.com/textioHQ/frontend/issues/2292