### PR TITLE
Allow users to copy when document is readOnly

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -34,6 +34,7 @@ const generateRandomKey = require('generateRandomKey');
 const getDefaultKeyBinding = require('getDefaultKeyBinding');
 const nullthrows = require('nullthrows');
 const getScrollPosition = require('getScrollPosition');
+const editOnSelect = require('editOnSelect');
 
 import type {BlockMap} from 'BlockMap';
 import type {DraftEditorModes} from 'DraftEditorModes';
@@ -188,6 +189,10 @@ class DraftEditor extends React.Component {
   _buildHandler(eventName: string): Function {
     return (e) => {
       if (!this.props.readOnly) {
+        const method = this._handler && this._handler[eventName];
+        method && method(this, e);
+      } else if (eventName === 'onCopy') {
+        editOnSelect(this)
         const method = this._handler && this._handler[eventName];
         method && method(this, e);
       }

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -192,6 +192,10 @@ class DraftEditor extends React.Component {
         const method = this._handler && this._handler[eventName];
         method && method(this, e);
       } else if (eventName === 'onCopy') {
+        // React does not fire onSelect for readonly divs (aka non-content-editable divs). If a user
+        // selects some text and hits 'copy' nothing will be copied because the selectState contains
+        // nothing :( Call editOnSelect to force the actual DOM selection onto the editor and then
+        // allow the normal copy method to do its thing.
         editOnSelect(this)
         const method = this._handler && this._handler[eventName];
         method && method(this, e);


### PR DESCRIPTION
Is `release` the correct base branch?

Allow users to copy text from a `finished` document. You'll need to be in the `topic-feature-fc-workflow` branch in `frontend` to put documents into a `finished` state. Selecting some text and pasting into Word should NOT include odd formatting (like colored text and boxes)
