### PR TITLE
Allow npm4 to check dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flowtype": "^2.17.1",
     "eslint-plugin-react": "^5.2.2",
-    "fbjs-scripts": "^0.7.0",
+    "fbjs-scripts": "^0.8.0",
     "flow-bin": "^0.42.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.2",


### PR DESCRIPTION
See https://github.com/facebook/draft-js/issues/914, which was fixed in https://github.com/facebook/fbjs/commit/e4d94dcb2bb4101c93067d62cf64e0a0fed489ae