### PR TITLE
plain entity type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.52",
+  "version": "0.10.52-topic-custom-entity-type",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.54-topic-custom-entity-type",
+  "version": "0.10.54-topic-custom-entity-type.0",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.54",
+  "version": "0.10.54-topic-custom-entity-type",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.53",
+  "version": "0.10.52-topic-custom-entity-type",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.52-topic-custom-entity-type",
+  "version": "0.10.52-topic-custom-entity-type.0",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/utils/DraftFeatureFlags.js
+++ b/src/component/utils/DraftFeatureFlags.js
@@ -13,7 +13,7 @@
 'use strict';
 
 var DraftFeatureFlags = {
-  draft_killswitch_allow_nontextnodes: true,
+  draft_killswitch_allow_nontextnodes: false,
   draft_segmented_entities_behavior: false,
 };
 

--- a/src/model/entity/DraftEntityMutability.js
+++ b/src/model/entity/DraftEntityMutability.js
@@ -39,6 +39,14 @@ var ComposedEntityMutability = require('ComposedEntityMutability');
  *   the entity from the entire range. Deleting characters within a segmented
  *   entity will delete only the segments affected by the deletion. Example:
  *   Facebook User mentions.
+ *
+ * `PLAIN`:
+ *   Plain entities lack the customized behavior of the other entity types, and
+ *   should be used when the desired behavior doesn't fall cleanly into the use
+ *   cases of the other entity types. They don't automatically expand like
+ *   mutable entities, and they aren't deleted like immutable or segmented
+ *   entities. They are designed to serve as a blank slate that custom behavior
+ *   can be build on top of.
  */
 
 export type DraftEntityMutability = $Keys<typeof ComposedEntityMutability>;

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -20,7 +20,7 @@ import type {EntityMap} from 'EntityMap';
 /**
  * Return the entity key that should be used when inserting text for the
  * specified target selection, only if the entity is `MUTABLE`. `IMMUTABLE`
- * and `SEGMENTED` entities should not be used for insertion behavior.
+ * `SEGMENTED`, and `PLAIN` entities should not be used for insertion behavior.
  */
 function getEntityKeyForSelection(
   contentState: ContentState,

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -130,7 +130,7 @@ function getEntityRemovalRange(
 
   // `MUTABLE` entities can just have the specified range of text removed
   // directly. No adjustments are needed.
-  if (mutability === 'MUTABLE') {
+  if (mutability === 'MUTABLE' || mutability === 'PLAIN') {
     return selectionState;
   }
 

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -72,6 +72,12 @@ describe('removeEntitiesAtEdges', () => {
         expectSameBlockMap(contentState, result);
       });
 
+      it('must not remove plain entities', () => {
+        setEntityMutability('PLAIN');
+        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
+        expectSameBlockMap(contentState, result);
+      });
+
       it('must remove immutable entities', () => {
         setEntityMutability('IMMUTABLE');
         var result = removeEntitiesAtEdges(contentState, selectionOnEntity);

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -100,7 +100,8 @@ function removeForBlock(
 
   if (entityAfterCursor && entityAfterCursor === entityBeforeCursor) {
     var entity = entityMap.__get(entityAfterCursor);
-    if (entity.getMutability() !== 'MUTABLE' && entity.getMutability() !== 'PLAIN') {
+    var mutability = entity.getMutability();
+    if (mutability !== 'MUTABLE' && mutability !== 'PLAIN') {
       var {start, end} = getRemovalRange(chars, entityAfterCursor, offset);
       var current;
       while (start < end) {

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -100,7 +100,7 @@ function removeForBlock(
 
   if (entityAfterCursor && entityAfterCursor === entityBeforeCursor) {
     var entity = entityMap.__get(entityAfterCursor);
-    if (entity.getMutability() !== 'MUTABLE') {
+    if (entity.getMutability() !== 'MUTABLE' && entity.getMutability() !== 'PLAIN') {
       var {start, end} = getRemovalRange(chars, entityAfterCursor, offset);
       var current;
       while (start < end) {

--- a/src/stubs/ComposedEntityMutability.js
+++ b/src/stubs/ComposedEntityMutability.js
@@ -16,6 +16,7 @@ var ComposedEntityMutability = {
   'MUTABLE': true,
   'IMMUTABLE': true,
   'SEGMENTED': true,
+  'PLAIN': true,
 };
 
 module.exports = ComposedEntityMutability;


### PR DESCRIPTION
All of the entity types built into draft are made for very specific use cases and have behaviors that make sense for that case, but not for anything else (`MUTABLE` entities grow unexpectedly, and `IMMUTABLE`/`SEGMENTED` entities have odd delete behavior).

This adds a `PLAIN` entity type without any additional behaviors. If it's put on a character, it stays on that character until the character is deleted or the character's entity key is changed. This creates a simple entity type whose behavior can be customized without having to correct for the behaviors of the other entity types.