### PR TITLE
Switched to decoratorKey instead of offsetKey for DecoratorComponent

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -189,7 +189,7 @@ class DraftEditorBlock extends React.Component {
           contentState={this.props.contentState}
           decoratedText={decoratedText}
           dir={dir}
-          key={decoratorOffsetKey}
+          key={decoratorKey}
           entityKey={block.getEntityAt(leafSet.get('start'))}
           offsetKey={decoratorOffsetKey}>
           {leaves}


### PR DESCRIPTION
Resolves [this bug](https://github.com/facebook/draft-js/issues/577) by ensuring that the key prop for each `DecoratorComponent` is the key of the decoration, not the offset key. 

This is crucial for any decorations that have internal state--without it, state can leak between components. It also helps to ensure the the components that are mounting/unmounting are the ones that should be doing that instead of random other ones.

This is also important for limiting the amount of DOM rearrangement that happens if a decoration is removed.