### PR TITLE
Switched to decoratorKey instead of offsetKey for decorations

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -189,7 +189,7 @@ class DraftEditorBlock extends React.Component {
           contentState={this.props.contentState}
           decoratedText={decoratedText}
           dir={dir}
-          key={decoratorOffsetKey}
+          key={decoratorKey}
           entityKey={block.getEntityAt(leafSet.get('start'))}
           offsetKey={decoratorOffsetKey}>
           {leaves}


### PR DESCRIPTION
Same as [this PR](https://github.com/textioHQ/draft-js/pull/61) except made to the right branch.