### PR TITLE
Remove the non-standard replace method

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -334,31 +334,6 @@ class EditorState {
   }
 
   /**
-   * Replace the contentState with the new one, without altering the undo stack
-   * This should only be used in limited circumstances where the selection is unaltered
-   * and the goal is to provide a silent transformation
-   */
-  static replace(
-    editorState: EditorState,
-    contentState: ContentState
-): EditorState {
-    var oldContent = editorState.getCurrentContent();
-    if (oldContent.getSelectionAfter() !== contentState.getSelectionAfter()) {
-      throw new Error('Cannot replace the content when the selection differs. Use push instead');
-    }
-
-    var directionMap = EditorBidiService.getDirectionMap(
-      contentState,
-      editorState.getDirectionMap()
-    );
-
-    return EditorState.set(editorState, {
-      currentContent: contentState,
-      directionMap,
-    });
-  }
-
-  /**
    * Push the current ContentState onto the undo stack if it should be
    * considered a boundary state, and set the provided ContentState as the
    * new current content.


### PR DESCRIPTION
This method is unnecessary and removing it brings us closer to parity with the main project.
