### PR TITLE
Export getDraftEditorSelection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.55-topic-ie-tooltips-phantom-cursor",
+  "version": "0.10.55-topic-ie-tooltips-phantom-cursor.0",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.55",
+  "version": "0.10.55-topic-ie-tooltips-phantom-cursor",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -39,6 +39,7 @@ const convertFromRawToDraftState = require('convertFromRawToDraftState');
 const generateRandomKey = require('generateRandomKey');
 const getDefaultKeyBinding = require('getDefaultKeyBinding');
 const getVisibleSelectionRect = require('getVisibleSelectionRect');
+const getDraftEditorSelection = require('getDraftEditorSelection');
 
 const DraftPublic = {
   Editor: DraftEditor,
@@ -71,6 +72,7 @@ const DraftPublic = {
   genKey: generateRandomKey,
   getDefaultKeyBinding,
   getVisibleSelectionRect,
+  getDraftEditorSelection,
 };
 
 module.exports = DraftPublic;


### PR DESCRIPTION
When focused, draft restores the selection of its `_latestEditorState`. To solve some IE bugs, we're doing things that trigger blur/focus events but need to make it seem as though the editor has was focused the whole time--specifically, if they mouse down in the editor, we need to move the selection to where they clicked. We've tried setting the selection ourselves, but draft also has logic designed to ignore selection events while it's updating (`_blockSelectEvents`). If that happens, our selection will go through, but draft won't update the editorState's selection, so the next time the user types it'll happen where the selection used to be.

Exporting this allows us to translate the desired selection into a draft selection state and apply it with `EditorState.forceSelection`.