### PR TITLE
Removed deployment section from circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,3 @@ machine:
 dependencies:
     post:
         - npm run build
-
-deployment:
-  production:
-    tag: /v[0-9]+(\.[0-9]+)*(-.*\.[0-9]+)?/
-    commands:
-      - npm run deploy


### PR DESCRIPTION
We trigger deployments manually now, so this is obsolete. It's also broken and causing builds to fail. 