### PR TITLE
Fix IE paste

### DIFF
--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -110,11 +110,13 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
     // It is important to call setMode('paste') to disable the editor's event handlers (so it is blisfully unaware)
     // and then to properly undo the sleight-of-hand created.
     editor.setMode('paste');
+    const selection = editor._latestEditorState.getCurrentContent().getSelectionAfter();
     const pasteTrap = editor._pasteTrap;
     pasteTrap.focus();
     setImmediate(() => {
       html = pasteTrap.innerHTML;
       editor.focus();
+      editor.update(EditorState.forceSelection(editor._latestEditorState, selection));
       pasteTrap.innerHTML = '';
       editor.exitCurrentMode();
       handleTextualPaste(editor, text, html);

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -110,7 +110,7 @@ function editOnPaste(editor: DraftEditor, e: DOMEvent): void {
     // It is important to call setMode('paste') to disable the editor's event handlers (so it is blisfully unaware)
     // and then to properly undo the sleight-of-hand created.
     editor.setMode('paste');
-    const selection = editor._latestEditorState.getCurrentContent().getSelectionAfter();
+    const selection = editor._latestEditorState.getSelection();
     const pasteTrap = editor._pasteTrap;
     pasteTrap.focus();
     setImmediate(() => {


### PR DESCRIPTION
In IE we paste by shifting focus between a trap contenteditable div (which collects what the browser thinks the paste should be) and the regular draft contenteditable. This shift of focus causes the cursor to be placed at the beginning of the document after pasting unless we do a forceSelection here. This should effectively be a noop.