### PR TITLE
[EN-1300] Custom wrapper template support

### DIFF
--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -234,27 +234,28 @@ class DraftEditorContents extends React.Component {
         // group those blocks by draftjs wrapper template
         const blocksGroupedByDraftWrapperTemplate = [];
         for (let j = 0; j < blocksGroupedByCustomTemplate.length;) {
-          const blocksGroupedByCustomTemplateAndDraftTemplate = [];
-          const baseCustomTemplateBlock = blocksGroupedByCustomTemplate[j];
-          if (baseCustomTemplateBlock.draftWrapperTemplate) {
+          const blocksGroupedByDraftWrapper = [];
+          const customWrapperBlock = blocksGroupedByCustomTemplate[j];
+          // Wrap by draft's internal wrapper if exists (li's for example)
+          if (customWrapperBlock.draftWrapperTemplate) {
             do {
-              blocksGroupedByCustomTemplateAndDraftTemplate.push(blocksGroupedByCustomTemplate[j].block);
+              blocksGroupedByDraftWrapper.push(blocksGroupedByCustomTemplate[j].block);
               j++;
             } while (
               j < blocksGroupedByCustomTemplate.length &&
-              blocksGroupedByCustomTemplate[j].draftWrapperTemplate === baseCustomTemplateBlock.draftWrapperTemplate
+              blocksGroupedByCustomTemplate[j].draftWrapperTemplate === customWrapperBlock.draftWrapperTemplate
             );
             const draftWrapperElement = React.cloneElement(
-              baseCustomTemplateBlock.draftWrapperTemplate,
+              customWrapperBlock.draftWrapperTemplate,
               {
-                key: baseCustomTemplateBlock.key + '-wrap',
-                'data-offset-key': baseCustomTemplateBlock.offsetKey,
+                key: customWrapperBlock.key + '-wrap',
+                'data-offset-key': customWrapperBlock.offsetKey,
               },
-              blocksGroupedByCustomTemplateAndDraftTemplate,
+              blocksGroupedByDraftWrapper,
             );
             blocksGroupedByDraftWrapperTemplate.push(draftWrapperElement);
           } else {
-            blocksGroupedByDraftWrapperTemplate.push(baseCustomTemplateBlock.block);
+            blocksGroupedByDraftWrapperTemplate.push(customWrapperBlock.block);
             j++;
           }
         }


### PR DESCRIPTION
Motivation: Being able to wrap draft in custom wrappers. In use today: <HeaderSection>, <FooterSection>.

Introducing `customWrapperTemplate` in addition to DraftJS's `wrapperTemplate`. Minimally invasive change, and is backwards compatible. Should we ever decide to remove it, everything should gracefully degrade back to the current way it is.

This allows for DraftJS to wrap by customWrapperTemplate then by the internal wrapperTemplate. Originally we were overwriting the internal wrapperTemplate implementation, causing anything internal to DraftJS that requires wrapping (most notably `ol/ul` w/ `li` elements) to break. This fixes it in a holistic way that can support other use cases around custom wrappers in the future, in addition to the current `<HeaderSection>` and `<FooterSection>` wrappers.

To see how this custom templates are passed through Editor, see this file -- https://github.com/textioHQ/editor/blob/master/src/TextioEditor/TextioEditor.js#L866
Unfortunately it's passed straight through to DraftJS, so not much can be done inside Editor without getting hacky. It takes a instance of a wrapper component passed to it (from `frontend`) and passes it to DraftJS to wrap the block items.