### PR TITLE
Ensure selectionState's 'hasFocus' is true after undo/redo

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -431,17 +431,15 @@ class EditorState {
       editorState.getDirectionMap()
     );
 
-    return EditorState.set(editorState, {
+    var newEditorState = EditorState.set(editorState, {
       currentContent: newCurrentContent,
       directionMap,
       undoStack: undoStack.shift(),
       redoStack: editorState.getRedoStack().push(currentContent),
-      forceSelection: true,
-      inlineStyleOverride: null,
       lastChangeType: 'undo',
-      nativelyRenderedContent: null,
-      selection: currentContent.getSelectionBefore(),
     });
+
+    return EditorState.forceSelection(newEditorState, currentContent.getSelectionBefore());
   }
 
   /**
@@ -465,17 +463,15 @@ class EditorState {
       editorState.getDirectionMap()
     );
 
-    return EditorState.set(editorState, {
+    var newEditorState = EditorState.set(editorState, {
       currentContent: newCurrentContent,
       directionMap,
       undoStack: editorState.getUndoStack().push(currentContent),
       redoStack: redoStack.shift(),
-      forceSelection: true,
-      inlineStyleOverride: null,
       lastChangeType: 'redo',
-      nativelyRenderedContent: null,
-      selection: newCurrentContent.getSelectionAfter(),
     });
+
+    return EditorState.forceSelection(newEditorState, newCurrentContent.getSelectionAfter());
   }
 
   /**


### PR DESCRIPTION
**Summary**

Undo and redo rely upon the selectionBefore/After stored in a contentState  to determine what the new selection should be. However, if EditorState.push() is called programmatically while the editor is out of focus, this means that a selectionState can get stored in a contentState's selectionBefore/After  where 'hasFocus' is false. If we then ever undo/redo onto this contentState, we'll restore a selectionState where 'hasFocus' is false. This is problematic because it will prevent the DOM selection from getting updated correctly, leading to a selectionState that does not match the actual selection in the DOM (which leads to all sorts of nastiness)

This change utilizes EditorState.forceSelection() within undo/redo to force the new selectionState to have 'hasFocus' equal to true. Since EditorState.forceSelection() also updates 'forceSelection', 'inlineStyleOverride', 'nativelyRenderedContent', and 'selection', we can remove them from being explicitly set via EditorState.set()