### PR TITLE
Add `silentlyUpdate` method

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -167,6 +167,7 @@ class DraftEditor extends React.Component {
     this.getClipboard = this._getClipboard.bind(this);
     this.getEditorKey = () => this._editorKey;
     this.update = this._update.bind(this);
+    this.silentlyUpdate = this._silentlyUpdate.bind(this);
     this.onDragEnter = this._onDragEnter.bind(this);
     this.onDragLeave = this._onDragLeave.bind(this);
 
@@ -425,6 +426,17 @@ class DraftEditor extends React.Component {
   _update(editorState: EditorState): void {
     this._latestEditorState = editorState;
     this.props.onChange(editorState);
+  }
+
+  /**
+   * If changes to upstream editor state are triggered by Draft *plugins*, they
+   * bypass `this.update` (which updates `this._latestEditorState`). However,
+   * `@textio/editor` treats `this._latestEditorState` as a source of truth. To
+   * avoid getting out of sync, plugins/editor can call `this._silentlyUpdate`
+   * after updating state.
+   */
+  _silentlyUpdate(editorState: EditorState): void {
+    this._latestEditorState = editorState;
   }
 
   /**


### PR DESCRIPTION
[EN-1250](https://textio.atlassian.net/browse/EN-1250) exposed a code path where Draft plugins can trigger change events in `editor` without ever passing through `DraftEditor` and updating `this._latestEditorState`. Trouble is, [`editor` treats `this._latestEditorState` as a source of truth](https://github.com/textioHQ/editor/blob/master/src/TextioEditor/TextioEditor.js#L371-L375), so plugin changes can cause problems with (temporarily) stale state.

This PR adds a new `silentlyUpdate` method—like `update`, it updates `this._latestEditorState`, but without calling `this.onChange`. Upstream code (in either `draft-js-plugins-editor` or `editor` itself) can call this to make sure state is consistent.