### PR TITLE
Remove lookUpwardForInlineStyle

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -617,8 +617,7 @@ function getInlineStyleForCollapsedSelection(
     return startBlock.getInlineStyleAt(0);
   }
 
-  // Otherwise, look upward in the document to find the closest character.
-  return lookUpwardForInlineStyle(content, startKey);
+  return OrderedSet();
 }
 
 function getInlineStyleForNonCollapsedSelection(
@@ -638,25 +637,6 @@ function getInlineStyleForNonCollapsedSelection(
   // style in the block.
   if (startOffset > 0) {
     return startBlock.getInlineStyleAt(startOffset - 1);
-  }
-
-  // Otherwise, look upward in the document to find the closest character.
-  return lookUpwardForInlineStyle(content, startKey);
-}
-
-function lookUpwardForInlineStyle(
-  content: ContentState,
-  fromKey: string,
-): DraftInlineStyle {
-  var previousBlock = content.getBlockBefore(fromKey);
-  var previousLength;
-
-  while (previousBlock) {
-    previousLength = previousBlock.getLength();
-    if (previousLength) {
-      return previousBlock.getInlineStyleAt(previousLength - 1);
-    }
-    previousBlock = content.getBlockBefore(previousBlock.getKey());
   }
 
   return OrderedSet();

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -131,22 +131,13 @@ describe('EditorState', () => {
         expect(editor.getCurrentInlineStyle()).toBe(BOLD);
       });
 
-      it('uses previous block at offset `0` within empty block', () => {
+      it('does not style empty blocks based on context', () => {
         var selection = mainSelection.merge({
           anchorKey: 'emptyA',
           focusKey: 'emptyA',
         });
         var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
-      });
-
-      it('looks upward through empty blocks to find a character', () => {
-        var selection = mainSelection.merge({
-          anchorKey: 'emptyB',
-          focusKey: 'emptyB',
-        });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
+        expect(editor.getCurrentInlineStyle()).toBe(NONE);
       });
 
       it('does not discard style override when changing block type', () => {
@@ -213,17 +204,6 @@ describe('EditorState', () => {
           focusOffset: 3,
         });
 
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
-      });
-
-      it('looks upward through empty blocks to find a character', () => {
-        var selection = selectionState.merge({
-          anchorKey: 'emptyA',
-          anchorOffset: 0,
-          focusKey: 'c',
-          focusOffset: 3,
-        });
         var editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(BOLD);
       });


### PR DESCRIPTION
When draft tries to calculate the inline-style for inserted characters, it looks at the text around it in the block, but if the block is empty, it looks at the style of the last character in the block before. That means that if you style the last word of a paragraph bold, select the next paragraph, and type to overwrite it, the inserted characters are bold instead of using the inline style of the overwritten text.

![look-upward-for-inline-style-bug](https://user-images.githubusercontent.com/16546625/43972494-6a2b5514-9c89-11e8-8168-f2a4706d0e38.gif)