### PR TITLE
[EN-995] Fix copying out of IE

### DIFF
--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -28,7 +28,7 @@ var getTextContentFromFiles = require('getTextContentFromFiles');
 const isEventHandled = require('isEventHandled');
 var splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
 var setImmediate = require('setImmediate');
-var UserAgent = require('UserAgent');
+var needsClipboardPolyfill = require('needsClipboardPolyfill');
 
 /**
  * Paste content.
@@ -221,13 +221,6 @@ function getHTML(data: DataTransfer) {
     return undefined;
   }
   return data.getHTML();
-}
-
-function needsClipboardPolyfill() {
-  const isEdge = UserAgent.isBrowser('Edge');
-  const isIE = UserAgent.isBrowser('IE');
-  const isSafari = UserAgent.isBrowser('Safari < 10');
-  return isEdge || isIE || isSafari;
 }
 
 function insertFragment(

--- a/src/component/handlers/edit/setClipboardData.js
+++ b/src/component/handlers/edit/setClipboardData.js
@@ -18,6 +18,7 @@ var UserAgent = require('UserAgent');
 var setImmediate = require('setImmediate');
 
 var isEdge = UserAgent.isBrowser('Edge');
+var needsClipboardPolyfill = require('needsClipboardPolyfill');
 
 function setClipboardData(e: SyntheticClipboardEvent, editor: DraftEditor, {text, html}): void {
 
@@ -29,7 +30,10 @@ function setClipboardData(e: SyntheticClipboardEvent, editor: DraftEditor, {text
     const testClipboardString = 'setting the clipboard works';
     clipboard.setData('Text', testClipboardString);
 
-    if (clipboard.getData('Text') !== testClipboardString) {
+    if (
+      clipboard.getData('Text') !== testClipboardString ||
+      needsClipboardPolyfill()
+    ) {
 
       doCopyTrap(editor, html);
       // Let the native event go through

--- a/src/component/utils/needsClipboardPolyfill.js
+++ b/src/component/utils/needsClipboardPolyfill.js
@@ -1,0 +1,18 @@
+/**
+ * @providesModule needsClipboardPolyfill
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var UserAgent = require('UserAgent');
+
+function needsClipboardPolyfill() {
+  const isEdge = UserAgent.isBrowser('Edge');
+  const isIE = UserAgent.isBrowser('IE');
+  const isSafari = UserAgent.isBrowser('Safari < 10');
+  return isEdge || isIE || isSafari;
+}
+
+module.exports = needsClipboardPolyfill;


### PR DESCRIPTION
Copy-pasting HTML doesn't work as expected in IE — surprise, surprise! (More context [here](https://www.lucidchart.com/techblog/2014/12/02/definitive-guide-copying-pasting-javascript/).) In the case of [EN-995](https://textio.atlassian.net/browse/EN-995), a customer reported being unable to copy documents from IE into Word without stripping formatting.

Our Draft fork has some custom logic for IE / Edge / older Safari, which involves copy/pasting into a hidden `contenteditable` div and copy/pasting _again_ from there. In the case of copying, [we check for Edge](https://github.com/textioHQ/draft-js/blob/1826c285e90a40d34e6e8e1977dc00f23cb2ed7a/src/component/handlers/edit/setClipboardData.js#L46-L49)... but not for IE, which also needs the workaround.

So, this PR:
* Pulls `needsClipboardPolyfill` out of `editOnPaste` into a standalone util
* In `setClipboardData`, adds the custom workaround for IE (and older Safari), not just Edge

