### PR TITLE
Pull in fix for bug when setting focus in IE/Firefox/Edge

### DIFF
--- a/src/component/handlers/edit/editOnFocus.js
+++ b/src/component/handlers/edit/editOnFocus.js
@@ -14,8 +14,8 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-var DraftFeatureFlags = require('DraftFeatureFlags');
 var EditorState = require('EditorState');
+var UserAgent = require('UserAgent');
 
 function editOnFocus(editor: DraftEditor, e: SyntheticFocusEvent): void {
   var editorState = editor._latestEditorState;
@@ -34,10 +34,13 @@ function editOnFocus(editor: DraftEditor, e: SyntheticFocusEvent): void {
   // selection here instead of simply accepting it in order to preserve the
   // old cursor position. See https://crbug.com/540004.
   // But it looks like this is fixed in Chrome 60.0.3081.0.
-  if (DraftFeatureFlags.draft_accept_selection_after_refocus) {
-    editor.update(EditorState.acceptSelection(editorState, selection));
-  } else {
+  // Other browsers also don't have this bug, so we prefer to acceptSelection
+  // when possible, to ensure that unfocusing and refocusing a Draft editor
+  // doesn't preserve the selection, matching how textareas work.
+  if (UserAgent.isBrowser('Chrome < 60.0.3081.0')) {
     editor.update(EditorState.forceSelection(editorState, selection));
+  } else {
+    editor.update(EditorState.acceptSelection(editorState, selection));
   }
 }
 

--- a/src/component/utils/DraftFeatureFlags-core.js
+++ b/src/component/utils/DraftFeatureFlags-core.js
@@ -13,7 +13,6 @@
 'use strict';
 
 var DraftFeatureFlags = {
-  draft_accept_selection_after_refocus: false,
   draft_killswitch_allow_nontextnodes: false,
   draft_segmented_entities_behavior: false,
 };


### PR DESCRIPTION
We have a bug in our fork of draft that has been fixed in the mainline repo (bug described [here](https://github.com/facebook/draft-js/issues/1055)). It is an especially annoying bug in IE/Edge, because it causes the editor scroll position to jump to where the cursor was last placed before the editor lost focus - meaning that if you click on the editor when it's scrolled to the bottom, focus may be placed at the top and scroll you all the way up. This PR pulls in the commit to Draft [here](https://github.com/facebook/draft-js/commit/19b9b1c5007bcb3a4111ea31f8d9a8cda629a1ff) that fixes the issue.

The following is the information from the original commit in Draft JS:

Summary: Don't need this any more. Chrome 60 is out.

Reviewed By: zpao

Differential Revision: D5674557

fbshipit-source-id: 878f620f6e91aa1271d13ffa644cd47540b21e76

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

[...]

**Test Plan**

[...]
