### PR TITLE
Remove link protocol validation

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -317,11 +317,8 @@ function hasValidLinkText(link: Node): boolean {
     'Link must be an HTMLAnchorElement.',
   );
   var protocol = link.protocol;
-  return (
-    protocol === 'http:' ||
-    protocol === 'https:' ||
-    protocol === 'mailto:'
-  );
+  // eslint-disable-next-line no-script-url
+  return protocol !== 'javascript:';
 }
 
 function genFragment(


### PR DESCRIPTION
We don't want to strip out links that use a different protocol, since we may have to support many more than just these.