### PR TITLE
EN-3178: Allow for multiple styles of textDecoration

### DIFF
--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -45,4 +45,17 @@ describe('convertFromHTMLToContentBlocks', () => {
     'p',
     'pre',
   ].forEach(tag => testConvertingAdjacentHtmlElementsToContentBlocks(tag));
+
+  it('applies textDecoration with multiple styles', () => {
+    const html = '<span style="text-decoration:underline line-through;">okurrrr</span>';
+    const blocks = convertFromHTMLToContentBlocks(html);
+    const charList = blocks.contentBlocks[0].characterList;
+
+    charList.forEach(charMetadata => {
+      const { style } = charMetadata;
+      expect(style.size).toBe(2);
+      expect(style.has('UNDERLINE')).toBeTruthy();
+      expect(style.has('STRIKETHROUGH')).toBeTruthy();
+    });
+  });
 });

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -238,7 +238,8 @@ function processInlineTag(
     currentStyle = currentStyle.withMutations(style => {
       const fontWeight = htmlElement.style.fontWeight;
       const fontStyle = htmlElement.style.fontStyle;
-      const textDecoration = htmlElement.style.textDecoration;
+      // text-decoration is CSS shorthand and can contain multiple decoration values
+      const textDecoration = htmlElement.style.textDecoration.split(' ');
 
       if (boldValues.indexOf(fontWeight) >= 0) {
         style.add('BOLD');
@@ -252,13 +253,13 @@ function processInlineTag(
         style.remove('ITALIC');
       }
 
-      if (textDecoration === 'underline') {
+      if (textDecoration.includes('underline')) {
         style.add('UNDERLINE');
       }
-      if (textDecoration === 'line-through') {
+      if (textDecoration.includes('line-through')) {
         style.add('STRIKETHROUGH');
       }
-      if (textDecoration === 'none') {
+      if (textDecoration.includes('none')) {
         style.remove('UNDERLINE');
         style.remove('STRIKETHROUGH');
       }


### PR DESCRIPTION
#sq-outlook wants to add support for italics, underline, and strikethrough to the Textio Outlook plugin. While testing copy & paste, I found that pastes from Google Docs didn't persist the underline or strikethrough styles since DraftJS only expected one or the other. These changes respect text styles that have both applied.

This is my first PR to our fork of DraftJS 🎉Please let me know if there are any special steps/concerns/etc. of which I should be aware.

Jira link: https://textio.atlassian.net/browse/EN-3178