### PR TITLE
Take 2: Allow for multiple styles of textDecoration

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "webpack-stream": "^3.0.0"
   },
   "devEngines": {
-    "node": "4.x || 6.x || 8.x || 10.x",
-    "npm": "2.x || 3.x || 6.x"
+    "node": "8.x || 10.x",
+    "npm": "5.x || 6.x"
   },
   "jest": {
     "automock": true,

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -45,4 +45,17 @@ describe('convertFromHTMLToContentBlocks', () => {
     'p',
     'pre',
   ].forEach(tag => testConvertingAdjacentHtmlElementsToContentBlocks(tag));
+
+  it('applies textDecoration with multiple styles', () => {
+    const html = '<span style="text-decoration:underline line-through;">okurrrr</span>';
+    const blocks = convertFromHTMLToContentBlocks(html);
+    const charList = blocks.contentBlocks[0].characterList;
+
+    charList.forEach(charMetadata => {
+      const { style } = charMetadata;
+      expect(style.size).toBe(2);
+      expect(style.has('UNDERLINE')).toBeTruthy();
+      expect(style.has('STRIKETHROUGH')).toBeTruthy();
+    });
+  });
 });

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -58,4 +58,15 @@ describe('convertFromHTMLToContentBlocks', () => {
       expect(style.has('STRIKETHROUGH')).toBeTruthy();
     });
   });
+
+  it('handles for undefined textDecoration', () => {
+    const html = '<span>bardi</span>';
+    const blocks = convertFromHTMLToContentBlocks(html);
+    const charList = blocks.contentBlocks[0].characterList;
+
+    charList.forEach(charMetadata => {
+      const { style } = charMetadata;
+      expect(style.size).toBe(0);
+    });
+  });
 });

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -240,7 +240,8 @@ function processInlineTag(
     currentStyle = currentStyle.withMutations(style => {
       const fontWeight = htmlElement.style.fontWeight;
       const fontStyle = htmlElement.style.fontStyle;
-      const textDecoration = htmlElement.style.textDecoration;
+      // text-decoration is CSS shorthand and can contain multiple decoration values
+      const textDecoration = htmlElement.style.textDecoration.split(' ');
 
       if (boldValues.indexOf(fontWeight) >= 0) {
         style.add('BOLD');
@@ -254,13 +255,13 @@ function processInlineTag(
         style.remove('ITALIC');
       }
 
-      if (textDecoration === 'underline') {
+      if (textDecoration.includes('underline')) {
         style.add('UNDERLINE');
       }
-      if (textDecoration === 'line-through') {
+      if (textDecoration.includes('line-through')) {
         style.add('STRIKETHROUGH');
       }
-      if (textDecoration === 'none') {
+      if (textDecoration.includes('none')) {
         style.remove('UNDERLINE');
         style.remove('STRIKETHROUGH');
       }

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -238,10 +238,9 @@ function processInlineTag(
   } else if (node instanceof HTMLElement) {
     const htmlElement = node;
     currentStyle = currentStyle.withMutations(style => {
-      const fontWeight = htmlElement.style.fontWeight;
-      const fontStyle = htmlElement.style.fontStyle;
+      let { fontWeight, fontStyle, textDecoration } = htmlElement.style;
       // text-decoration is CSS shorthand and can contain multiple decoration values
-      const textDecoration = htmlElement.style.textDecoration.split(' ');
+      textDecoration = textDecoration && textDecoration.split(' ') || [];
 
       if (boldValues.indexOf(fontWeight) >= 0) {
         style.add('BOLD');


### PR DESCRIPTION
Exact same as #89 but this time branched from `release` instead of `master`.
Also removed some old `devEngine` versions so others aren't thrown off by a misleading syntax error thrown by Jest.