### PR TITLE
Native composition for iPadOs

### DIFF
--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -45,7 +45,17 @@ let textInputData = '';
 
 var DraftEditorCompositionHandler = {
   onBeforeInput: function(editor: DraftEditor, e: SyntheticInputEvent): void {
-    textInputData = (textInputData || '') + e.data;
+    // When we're consuming native events (detected by the lact of a `nativeEvent` accessor), we discard
+    // `insertCompositionText` events, that information will be captured with the insertFromComposition event.
+    //
+    // For reference, the other key input types around composition are:
+    // deleteCompositionText and insertFromComposition,
+    if (!e.nativeEvent && e.inputType === 'insertCompositionText') {
+      return;
+
+    } else if (e.data) {
+      textInputData = (textInputData || '') + e.data;
+    }
   },
 
   /**


### PR DESCRIPTION
**Context**: This is meant to support iPadOs/Safari.  It is not a good long term solution, but seems to address the issue I came across when consuming event natively in Safari.

When we're consuming native events (detected by the lack of a `nativeEvent` accessor), we discard `insertCompositionText` events, that information will be captured with the insertFromComposition event.

CAVEATS: This has only been tested on Safari, and native event handling with this branch is known to break chrome.