### PR TITLE
Take snapshot on comp start & restore on comp end if needed

### DIFF
--- a/src/component/handlers/composite-android/ElementSnapshot.js
+++ b/src/component/handlers/composite-android/ElementSnapshot.js
@@ -1,0 +1,72 @@
+// See https://github.com/ianstormtaylor/slate/pull/2565/files#diff-dfb45b3faad4511630e8699d68f62ee9R23
+
+function isTextNode(node) {
+  return node.type === Node.TEXT_NODE;
+}
+
+function getElementSnapshot(node) {
+  const snapshot = {};
+  snapshot.node = node;
+  if (isTextNode(node)) {
+    snapshot.text = node.textContent;
+  }
+  snapshot.children = Array.from(node.childNodes).map(getElementSnapshot);
+  return snapshot;
+}
+
+function applyElementSnapshot(snapshot) {
+  const node = snapshot.node;
+  if (isTextNode(node)) {
+    node.textContent = snapshot.text;
+  } else {
+    snapshot.children.forEach(child => {
+      applyElementSnapshot(child);
+      node.appendChild(child.node);
+    });
+    while (node.childNodes.length > snapshot.children.length) {
+      node.removeChild(node.childNodes[0]);
+    }
+  }
+}
+
+function getSnapshot(elements = []) {
+  const last = elements[elements.length - 1];
+  return {
+    elements: elements.map(getElementSnapshot),
+    parent: last.parentElement,
+    next: last.nextElementSibling,
+  };
+}
+
+function applySnapshot(snapshot) {
+  const { elements, parent, next } = snapshot;
+  elements.forEach(applyElementSnapshot);
+  const last = elements[elements.length - 1];
+
+  if (next) {
+    parent.insertBefore(last.node, next);
+  } else {
+    parent.appendChild(last.node);
+  }
+
+  let prev = last.node;
+  elements
+    .slice(-1)
+    .reverse()
+    .forEach(({ node }) => {
+      parent.insertBefore(node, prev);
+      prev = node;
+    });
+}
+
+class ElementSnapshot {
+  constructor(elements) {
+    this.snapshot = getSnapshot(elements);
+  }
+
+  apply() {
+    applySnapshot(this.snapshot);
+  }
+}
+
+module.exports = ElementSnapshot;


### PR DESCRIPTION
When the DOM is modified from under react, it can sometimes blow up with an error like `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.` when it tries to unmount components whose nodes are no longer present. It isn't sufficient to replace it with an identical node, it needs to be the same one (seems like react stores references somewhere).

To solve this, we take a snapshot of the DOM on compositionstart & store references to all the nodes, then restore the DOM to that state on compositionends that change the text so that react sees what it expects after we update the state and it rerenders.

Based on See https://github.com/ianstormtaylor/slate/pull/2565