### PR TITLE
Fix off-by-one at start of paragraph

### DIFF
--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -89,7 +89,7 @@ function findCoveringIndex(contentState, selection, textToFind) {
 
   if (
     // Ensure the match exists and contains the selection
-    matchStartOffset > 0 &&
+    matchStartOffset >= 0 &&
     matchStartOffset <= selStartOffset &&
     matchStartOffset + textToFind.length >= selStartOffset
   ) {


### PR DESCRIPTION
We weren't able to match composition ranges at the start of paragraphs because of this.