### PR TITLE
Topic restore editor dom

### DIFF
--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule DraftEditorCompositionHandler
+ * @providesModule DraftEditorCompositionHandlerAndroid
+ * @typechecks
  * @flow
  */
 
@@ -26,6 +27,7 @@ let hasInsertedCompositionText = false;
 let hasMutation = false;
 
 const resetCompositionData = () => {
+  createMutationObserverIfUndefined();
   compositionRange = undefined;
   compositionText = undefined;
   hasInsertedCompositionText = false;
@@ -37,7 +39,14 @@ const handleMutations = records => {
   mutationObserver.disconnect();
 };
 
-const mutationObserver = new MutationObserver(handleMutations);
+let mutationObserver = undefined;
+
+// Need to create mutation observer on runtime, not compile time
+const createMutationObserverIfUndefined = () => {
+  if (!mutationObserver) {
+    mutationObserver = new window.MutationObserver(handleMutations);
+  }
+};
 
 /**
  * Replace the current selection with the specified text string, with the
@@ -117,7 +126,7 @@ function findCoveringIndex(contentState, selection, textToFind) {
   return selection;
 }
 
-var DraftEditorCompositionHandler = {
+var DraftEditorCompositionHandlerAndroid = {
   /**
    * A `compositionstart` event has fired while we're still in composition
    * mode. Continue the current composition session to prevent a re-render.
@@ -186,4 +195,4 @@ var DraftEditorCompositionHandler = {
 
 };
 
-module.exports = DraftEditorCompositionHandler;
+module.exports = DraftEditorCompositionHandlerAndroid;

--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -61,6 +61,12 @@ function replaceText(
 }
 
 const getCompositionRange = (editor, text) => {
+  // Ocassionally a newline will get composed.  In this case, we want to strip it since
+  // we won't be able to match it in Draft, and it will get rewritten anyways.
+  if (text.endsWith('\n')) {
+    text = text.slice(0, text.length - 1);
+  }
+
   if (!text) {
     // get Selection (Assuming editorState is correct…)
     // Since we know editorState is often out of sync right now, derive from the DOM:

--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -19,7 +19,6 @@ const EditorState = require('EditorState');
 const ReactDOM = require('ReactDOM');
 
 const getDraftEditorSelection = require('getDraftEditorSelection');
-const ElementSnapshot = require('ElementSnapshot');
 
 let compositionRange = undefined;
 let compositionText = undefined;
@@ -135,11 +134,27 @@ var DraftEditorCompositionHandler = {
             EditorState.set(nextEditorState, {inCompositionMode: false}),
         );
     } else {
+      // TODO only restore editor dom when a node has been deleted.
+      const mustReset = true;
+      if (mustReset) {
+        editor.restoreEditorDOM();
+      }
+
       const nextEditorState = replaceText(editor._latestEditorState, newText, compositionRange);
 
       editor.setMode('edit');
+      const editorStateProps = mustReset ? {
+        // TODO this is done in the draft composition handler, but I am not sure we should.
+        nativelyRenderedContent: null,
+        forceSelection: true,
+      } : {
+        // pass in nativelyRenderedContent here?
+      };
       editor.update(
-        EditorState.set(nextEditorState, { inCompositionMode: false }),
+        EditorState.set(nextEditorState, {
+          inCompositionMode: false,
+          ...editorStateProps,
+        }),
       );
     }
     resetCompositionData();

--- a/src/component/handlers/edit/editOnBeforeInputAndroid.js
+++ b/src/component/handlers/edit/editOnBeforeInputAndroid.js
@@ -7,7 +7,6 @@ const ReactDOM = require('ReactDOM');
 
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
-const UserAgent = require('UserAgent');
 const getDraftEditorSelection = require('getDraftEditorSelection');
 const invariant = require('invariant');
 


### PR DESCRIPTION
This is partial work towards something more functional.

Draft already handles the react reconciliation case. editor.restoreEditorDOM(); does the trick.  That said, I think it re-renders the whole editor though we watch for mutation events to skip that behavior unless it's required.

This also includes fixes to the composition range matching where it can include an unmatchable newline.
