### PR TITLE
Force the selection after return on android

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInputAndroid.js
+++ b/src/component/handlers/edit/editOnBeforeInputAndroid.js
@@ -162,7 +162,12 @@ function editOnBeforeInputAndroid(editor: DraftEditor, e: InputEvent): void {
     case 'insertParagraph':
       logChanges(editor, () => {
         e.preventDefault();
-        editor.update(keyCommandInsertNewline(editorStateWithCorrectSelection));
+        const newState = keyCommandInsertNewline(
+          editorStateWithCorrectSelection,
+        );
+        editor.update(
+          EditorState.forceSelection(newState, newState.getSelection()),
+        );
       });
       return;
 


### PR DESCRIPTION
https://textio.atlassian.net/browse/EN-7609

Without this, sometimes the selection goes to the right spot when you press enter & sometimes it doesn't, although I haven't found a reliable repro.
