### PR TITLE
Only make text editable if it isn't read only

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -287,7 +287,7 @@ class DraftEditor extends React.Component {
       whiteSpace: 'pre-wrap',
       wordWrap: 'break-word',
       // Ensures that the native iOS text editing tooltip doesn't show up inside the contenteditable
-      ...(isWebKit && {
+      ...(isWebKit && !readOnly && {
         WebkitUserModify: 'read-write-plaintext-only',
       }),
     };


### PR DESCRIPTION
This style makes elements editable, so it shouldn't be applied to readonly documents