### PR TITLE
Adds support for copy and paste in Android (EN-7510)

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInputAndroid.js
+++ b/src/component/handlers/edit/editOnBeforeInputAndroid.js
@@ -154,7 +154,8 @@ function editOnBeforeInputAndroid(editor: DraftEditor, e: InputEvent): void {
     }
 
     case 'insertFromPaste': {
-      // Allow insert `insertFromPaste` to pass through.
+      // Allow insert `insertFromPaste` to pass through, it will be handled in the Android handler
+      // by `editOnPaste`.
       return;
     }
 


### PR DESCRIPTION
This largely hooks up the existing handlers for cut, copy, and paste.  Cut however is handled as a copy and delete so that it fits into the other beforeInput events.

Copy works without modification.

Paste on Android needs a forceSelection to place the cursor in the correct place, and the most reliable way to keep the keyboard open after a paste appears to be putting it into a setImmediate. This isn't fool proof, but it usually works.