### PR TITLE
Exit composition mode when idle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js",
-  "version": "0.10.82",
+  "version": "0.10.82-topic-composition-timeout.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.82",
+  "version": "0.10.82-topic-composition-timeout",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.82-topic-composition-timeout",
+  "version": "0.10.82-topic-composition-timeout.0",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -22,16 +22,18 @@ const EditorState = require('EditorState');
 const ReactDOM = require('ReactDOM');
 
 const getDraftEditorSelection = require('getDraftEditorSelection');
-
+const compositionTimeoutDelay = 1500;
 
 let hasMutation = false;
 let mutationObserver = null;
 let compositionState = null;
+let compositionTimeoutId = null;
 
 const resetCompositionData = (editor) => {
   createMutationObserverIfUndefined();
   hasMutation = false;
   compositionState = getEditorState(editor);
+  cancelCompositionTimeout();
 };
 
 const handleMutations = records => {
@@ -44,6 +46,52 @@ const createMutationObserverIfUndefined = () => {
   if (!mutationObserver) {
     mutationObserver = new window.MutationObserver(handleMutations);
   }
+};
+
+const startCompositionTimeout = (editor) => {
+  cancelCompositionTimeout();
+
+  if (!getEditorState(editor).isInCompositionMode()) {
+    //editor.update(EditorState.set(getEditorState(editor), { inCompositionMode: true }));
+    editor.silentlyUpdate(EditorState.set(getEditorState(editor), { inCompositionMode: true }));
+  }
+
+  compositionTimeoutId = setTimeout(() => {
+    // If we are at a safe point to exit composition mode, do so to let renders through.
+    const editorState = getEditorState(editor);
+    if (editorState.isInCompositionMode() && isSafeToExitCompositionMode(editor, compositionState)) {
+      DraftEditorCompositionHandlerAndroid.commit(editor, compositionState);
+    }
+  }, compositionTimeoutDelay);
+};
+
+const cancelCompositionTimeout = () => {
+  if (compositionTimeoutId) {
+    clearTimeout(compositionTimeoutId);
+    compositionTimeoutId = null;
+  }
+};
+
+/**
+ * Checks to see if the uncommitted composition state can safely be updated.
+ * If a composition range is updated, the caret _should_ move to the end of the range.
+ * This means we can allow updates through when the caret wouldn't be moved.
+ *
+ * @param {DraftEditor} current editor
+ * @param {EditorState} compositionState
+ */
+const isSafeToExitCompositionMode = (editor, compositionState: EditorState) => {
+  const selection = deriveSelectionFromDOM(editor);
+  const block = compositionState
+        .getCurrentContent()
+        .getBlockForKey(selection.getEndKey());
+
+  const offset = selection.getEndOffset();
+  const char = block.getText()[offset];
+
+  // Check to see if the following character is a non word character, if
+  // it should be safe to allow the composition to change.
+  return (!char || char.match(/\W/));
 };
 
 /**
@@ -80,9 +128,11 @@ const deriveSelectionFromDOM = (editor: DraftEditor): SelectionState => {
 };
 
 var DraftEditorCompositionHandlerAndroid = {
-  update: (editor, editorState) => {
-    editor.setMode('edit');
-    editor.update(EditorState.set(editorState, { inCompositionMode: false }));
+  commit: (editor, editorState) => {
+    const selection = deriveSelectionFromDOM(editor);
+    const nextEditorState = EditorState.acceptSelection(editorState, selection);
+    editor.update(EditorState.set(nextEditorState, { inCompositionMode: false }));
+
     resetCompositionData(editor);
   },
 
@@ -105,29 +155,36 @@ var DraftEditorCompositionHandlerAndroid = {
     e: SyntheticCompositionEvent,
   ): void {
     resetCompositionData(editor);
+    startCompositionTimeout(editor);
     mutationObserver.observe(
       getEditorNode(editor),
       { childList: true, subtree: true },
     );
   },
 
+  onCompositionUpdate: function(
+    editor: DraftEditor,
+    e: SyntheticCompositionEvent,
+  ): void {
+    startCompositionTimeout(editor);
+  },
+
   onCompositionEnd: function(
     editor: DraftEditor,
     e: SyntheticCompositionEvent,
   ): void {
+    // If no mutation has been detected yet, flush any pending events.
     if (!hasMutation) {
       handleMutations(mutationObserver.takeRecords());
     }
+
+    // If there are mutations now, restore the dom to prevent React from failing during reconciliation.
     if (hasMutation) {
       editor.restoreEditorDOM();
     }
 
-    const selection = deriveSelectionFromDOM(editor);
-    const nextEditorState = EditorState.acceptSelection(compositionState, selection);
-    DraftEditorCompositionHandlerAndroid.update(
-      editor,
-      nextEditorState,
-    );
+    editor.setMode('edit');
+    DraftEditorCompositionHandlerAndroid.commit(editor, compositionState);
   },
 };
 


### PR DESCRIPTION
When the user has not modfied the dom for a while, and the caret is in a safe location, we switch out of composition mode.

This allows async updates such as text highlighting and so forth.  It does however increase the opportunity for the composition state to get out of sync with draft.