### PR TITLE
Exit composition mode anywhere in text

### DIFF
--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -61,7 +61,7 @@ const startCompositionTimeout = (editor) => {
   compositionTimeoutId = setTimeout(() => {
     // If we are at a safe point to exit composition mode, do so to let renders through.
     const editorState = getEditorState(editor);
-    if (editorState.isInCompositionMode() && isSafeToExitCompositionMode(editor, compositionState)) {
+    if (editorState.isInCompositionMode()) {
       DraftEditorCompositionHandlerAndroid.commit(editor, compositionState);
     }
   }, compositionTimeoutDelay);
@@ -72,29 +72,6 @@ const cancelCompositionTimeout = () => {
     clearTimeout(compositionTimeoutId);
     compositionTimeoutId = null;
   }
-};
-
-/**
- * Checks to see if the uncommitted composition state can safely be updated.
- * If a composition range is updated, the caret _should_ move to the end of the range.
- * This means we can allow updates through when the caret wouldn't be moved.
- *
- * @param {DraftEditor} current editor
- * @param {EditorState} compositionState
- */
-const isSafeToExitCompositionMode = (editor, compositionState: EditorState) => {
-  const selection = deriveSelectionFromDOM(editor);
-  const block = compositionState
-        .getCurrentContent()
-        .getBlockForKey(selection.getEndKey());
-
-  // The end offset is exclusive, so this will get the character following the caret.
-  const offset = selection.getEndOffset();
-  const char = block.getText()[offset];
-
-  // Check to see if the following character is a non word character, if
-  // it is, it should be safe to allow the composition to change.
-  return (!char || char.match(/\W/));
 };
 
 /**


### PR DESCRIPTION
This safety check turned out to be unnecessary and now it is causing other bugs:
 * https://textio.atlassian.net/browse/EN-9244
 * https://textio.atlassian.net/browse/EN-9230
 * https://textio.atlassian.net/browse/EN-9253

We would allow rerenders after a delay if the user's selection was at the end of a word or paragraph, but not if the selection was anywhere else, which is why the bugs above were inconsistent/difficult to repro. This PR removes that safety check (which doesn't seem necessary) so that the editor rerenders consistently after a debounced delay regardless of the user's selection.