### PR TITLE
Add onBlur support to Android edit handler (EN-8901)

### DIFF
--- a/src/component/handlers/edit/DraftEditorEditAndroidHandler.js
+++ b/src/component/handlers/edit/DraftEditorEditAndroidHandler.js
@@ -16,6 +16,7 @@ const EditorState = require('EditorState');
 
 const onBeforeInput = require('editOnBeforeInputAndroid');
 const onBlur = require('editOnBlur');
+const onFocus = require('editOnFocus');
 const onKeyDown = require('editOnKeyDown');
 const onCompositionStart = require('editOnCompositionStart');
 const onSelect = require('editOnSelect');
@@ -63,6 +64,7 @@ function handleKeyDown(editor, e) {
 const DraftEditorEditAndroidHandler = {
   onBeforeInput,
   onBlur,
+  onFocus,
   onCompositionStart,
   onCopy,
   onPaste: handlePaste,

--- a/src/component/handlers/edit/DraftEditorEditAndroidHandler.js
+++ b/src/component/handlers/edit/DraftEditorEditAndroidHandler.js
@@ -15,6 +15,7 @@
 const EditorState = require('EditorState');
 
 const onBeforeInput = require('editOnBeforeInputAndroid');
+const onBlur = require('editOnBlur');
 const onKeyDown = require('editOnKeyDown');
 const onCompositionStart = require('editOnCompositionStart');
 const onSelect = require('editOnSelect');
@@ -61,6 +62,7 @@ function handleKeyDown(editor, e) {
 // Only handle the following events:
 const DraftEditorEditAndroidHandler = {
   onBeforeInput,
+  onBlur,
   onCompositionStart,
   onCopy,
   onPaste: handlePaste,


### PR DESCRIPTION
This PR fixes an issue where the editor's onBlur handler wasn't getting called on Android. This meant that `hasFocus` wasn't getting set to `false` on blur, which caused the editor to receive focus when changing templates.

I have no context for this area of our code base. Could adding this onBlur handler cause any negative side effects? It seems to work great in my testing.

https://textio.atlassian.net/browse/EN-8901