### PR TITLE
Prevent composition reconciliation errors (EN-8904)

### DIFF
--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -62,6 +62,14 @@ const startCompositionTimeout = (editor) => {
     // If we are at a safe point to exit composition mode, do so to let renders through.
     const editorState = getEditorState(editor);
     if (editorState.isInCompositionMode()) {
+      if (hasMutation) {
+        setImmediate(() => {
+          // Restore the DOM after we switch Draft out of composition mode so the cursor
+          // returns to the expected place.  This may cause the keyboard suggestions to blink,
+          // but it's required to prevent errors during reconciliation.
+          editor.restoreEditorDOM();
+        });
+      }
       DraftEditorCompositionHandlerAndroid.commit(editor, compositionState);
     }
   }, compositionTimeoutDelay);
@@ -90,6 +98,7 @@ function replaceText(
       text,
       inlineStyle,
   );
+
   return EditorState.push(editorState, contentState, 'insert-characters');
 }
 
@@ -123,15 +132,12 @@ var DraftEditorCompositionHandlerAndroid = {
 
   onBeforeInput: function(editor: DraftEditor, e: InputEvent): void {
     if (e.inputType === 'insertCompositionText') {
-      const nextEditorState = replaceText(
+      compositionState = replaceText(
         compositionState,
         e.data,
         deriveSelectionFromDOM(editor),
         getEditorState(editor).getCurrentInlineStyle(),
       );
-      compositionState = EditorState.set(nextEditorState, {
-        nativelyRenderedContent: nextEditorState.getCurrentContent(),
-      });
     }
   },
 
@@ -163,13 +169,19 @@ var DraftEditorCompositionHandlerAndroid = {
       handleMutations(mutationObserver.takeRecords());
     }
 
-    // If there are mutations now, restore the dom to prevent React from failing during reconciliation.
     if (hasMutation) {
+      // If there are mutations now, restore the dom to prevent React from failing during reconciliation.
       editor.restoreEditorDOM();
+    } else {
+      // If there are no mutations Draft is unaware of (deletions), flag it as native content.
+      compositionState = EditorState.set(compositionState, {
+        nativelyRenderedContent: compositionState.getCurrentContent(),
+      });
     }
 
     editor.setMode('edit');
     DraftEditorCompositionHandlerAndroid.commit(editor, compositionState);
+    cancelCompositionTimeout();
   },
 };
 

--- a/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
+++ b/src/component/handlers/composite-android/DraftEditorCompositionHandlerAndroid.js
@@ -63,12 +63,12 @@ const startCompositionTimeout = (editor) => {
     const editorState = getEditorState(editor);
     if (editorState.isInCompositionMode()) {
       if (hasMutation) {
-        setImmediate(() => {
+        setTimeout(() => {
           // Restore the DOM after we switch Draft out of composition mode so the cursor
           // returns to the expected place.  This may cause the keyboard suggestions to blink,
           // but it's required to prevent errors during reconciliation.
           editor.restoreEditorDOM();
-        });
+        }, 0);
       }
       DraftEditorCompositionHandlerAndroid.commit(editor, compositionState);
     }
@@ -164,6 +164,10 @@ var DraftEditorCompositionHandlerAndroid = {
     editor: DraftEditor,
     e: SyntheticCompositionEvent,
   ): void {
+    // Prevent the composition timeout from kicking in after the user
+    // exits composition mode.
+    cancelCompositionTimeout();
+
     // If no mutation has been detected yet, flush any pending events.
     if (!hasMutation) {
       handleMutations(mutationObserver.takeRecords());
@@ -181,7 +185,6 @@ var DraftEditorCompositionHandlerAndroid = {
 
     editor.setMode('edit');
     DraftEditorCompositionHandlerAndroid.commit(editor, compositionState);
-    cancelCompositionTimeout();
   },
 };
 


### PR DESCRIPTION
This only affects Android.

Content that requires `restoreEditorDOM` no longer gets flagged as `nativelyRenderedContent`.  This was causing Draft to skip re-rendering in some cases.

Additionally, when exiting composition mode rendering in the timeout, we now force a re-render in a `setImmediate` to force draft to clean up content.  This does cause the keyboard to flicker if there was a mutation, though this only practically seems to happen when starting a new block.

The `onCompositionEnd` and timeout codepaths could use a little clean up to clarify concerns, but for now this works.